### PR TITLE
Respect Angular schematics defaults for extracted components

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 	],
 	"activationEvents": [
 		"onLanguage:html",
-		"onCommand:extension.arrr.extract-to-folder"
+		"onCommand:extension.arrr.extract-to-folder",
+		"onCommand:extension.arrr.inline-component"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -27,6 +28,10 @@
 			{
 				"command": "extension.arrr.extract-to-folder",
 				"title": "Extract Angular component to folder"
+			},
+			{
+				"command": "extension.arrr.inline-component",
+				"title": "Inline Angular component into current component"
 			}
 		]
 	},

--- a/src/angular-config.ts
+++ b/src/angular-config.ts
@@ -1,0 +1,111 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface GeneratedComponentOptions {
+  styleExt: string;
+  skipTests: boolean;
+}
+
+interface AngularSchematicsOptions {
+  style?: string;
+  skipTests?: boolean;
+}
+
+export function resolveGeneratedComponentOptions(
+  workspaceRootPath: string | undefined,
+  sourceStyleExt: string,
+  sourceFilePath?: string
+): GeneratedComponentOptions {
+  const defaults: GeneratedComponentOptions = {
+    styleExt: sourceStyleExt || 'css',
+    skipTests: false,
+  };
+
+  if (!workspaceRootPath) {
+    return defaults;
+  }
+
+  const angularJsonPath = path.join(workspaceRootPath, 'angular.json');
+  if (!fs.existsSync(angularJsonPath)) {
+    return defaults;
+  }
+
+  try {
+    const angularConfig = JSON.parse(fs.readFileSync(angularJsonPath, 'utf8'));
+
+    const workspaceOptions = getComponentSchematicsOptions(angularConfig.schematics);
+    const projectOptions = getProjectComponentSchematicsOptions(
+      angularConfig.projects,
+      workspaceRootPath,
+      sourceFilePath
+    );
+
+    const merged = {
+      ...workspaceOptions,
+      ...projectOptions,
+    };
+
+    return {
+      styleExt: normalizeStyleExtension(merged.style, defaults.styleExt),
+      skipTests: typeof merged.skipTests === 'boolean' ? merged.skipTests : defaults.skipTests,
+    };
+  } catch (err) {
+    return defaults;
+  }
+}
+
+function getProjectComponentSchematicsOptions(
+  projects: any,
+  workspaceRootPath: string,
+  sourceFilePath?: string
+): AngularSchematicsOptions {
+  if (!projects || typeof projects !== 'object') {
+    return {};
+  }
+
+  const projectEntries = Object.entries(projects) as Array<[string, any]>;
+  const matched = sourceFilePath
+    ? projectEntries.find(([, project]) => {
+        const projectRoot = path.resolve(workspaceRootPath, project.root || '');
+        return sourceFilePath.startsWith(projectRoot);
+      })
+    : undefined;
+
+  if (matched) {
+    return getComponentSchematicsOptions(matched[1].schematics);
+  }
+
+  for (const [, project] of projectEntries) {
+    const options = getComponentSchematicsOptions(project.schematics);
+    if (Object.keys(options).length > 0) {
+      return options;
+    }
+  }
+
+  return {};
+}
+
+function getComponentSchematicsOptions(schematics: any): AngularSchematicsOptions {
+  if (!schematics || typeof schematics !== 'object') {
+    return {};
+  }
+
+  if (schematics['@schematics/angular:component']) {
+    return schematics['@schematics/angular:component'];
+  }
+
+  const componentKey = Object.keys(schematics).find((key) => key.endsWith(':component'));
+  if (!componentKey) {
+    return {};
+  }
+
+  return schematics[componentKey];
+}
+
+function normalizeStyleExtension(style: string | undefined, fallback: string): string {
+  if (!style || style === 'none') {
+    return fallback;
+  }
+
+  return style.replace(/^\./, '');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 
 import {extractToFolder} from './modules/extract-to-folder';
+import {inlineComponentIntoCurrentComponent} from './modules/inline-component-command';
 import {templateParser} from './template-parser';
 import {getSelectedText} from './editor';
 
@@ -15,12 +16,21 @@ export class CompleteActionProvider implements vscode.CodeActionProvider {
       try {
         const output = templateParser.parse(text);
         if (!output.errors) {
-          return [
+          const actions: vscode.Command[] = [
             {
               command: 'extension.arrr.extract-to-folder',
               title: 'Extract Angular Component',
             },
           ];
+
+          if (/^\s*<\s*[a-zA-Z][\w-]*-[\w-]+\b/.test(text)) {
+            actions.push({
+              command: 'extension.arrr.inline-component',
+              title: 'Inline Angular Component',
+            });
+          }
+
+          return actions;
         }
       } catch (err) {
       }
@@ -37,6 +47,13 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'extension.arrr.extract-to-folder',
       extractToFolder
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'extension.arrr.inline-component',
+      inlineComponentIntoCurrentComponent
     )
   );
 

--- a/src/modules/extract-to-folder.ts
+++ b/src/modules/extract-to-folder.ts
@@ -26,6 +26,7 @@ import {
   getComponentText,
   getSpecText,
 } from "./extract-to-folder-template";
+import { resolveGeneratedComponentOptions } from "../angular-config";
 
 export async function extractToFolder() {
   const { start, end } = getSelectionOffsetRange();
@@ -38,6 +39,11 @@ export async function extractToFolder() {
       );
       const targets = getAllTargets(text);
       const sourceComponentConfig = await getCurrentComponentConfig(componentText);
+      const generatedComponentOptions = resolveGeneratedComponentOptions(
+        workspaceRoot(),
+        sourceComponentConfig.styleExt,
+        activeFileName()
+      );
 
       try {
         const rootPath = workspaceRoot();
@@ -52,25 +58,33 @@ export async function extractToFolder() {
         }
 
         const htmlFilePath = `${fullPath}/${fileName}.component.html`;
-        const cssFilePath = `${fullPath}/${fileName}.component.${sourceComponentConfig.styleExt}`;
+        const cssFilePath = `${fullPath}/${fileName}.component.${generatedComponentOptions.styleExt}`;
         const tsFilePath = `${fullPath}/${fileName}.component.ts`;
         const specFilePath = `${fullPath}/${fileName}.component.spec.ts`;
 
         await createFileIfDoesntExist(htmlFilePath);
         await createFileIfDoesntExist(cssFilePath);
         await createFileIfDoesntExist(tsFilePath);
-        await createFileIfDoesntExist(specFilePath);
+        if (!generatedComponentOptions.skipTests) {
+          await createFileIfDoesntExist(specFilePath);
+        }
 
         await appendSelectedTextToFile({ text }, htmlFilePath);
         await appendSelectedTextToFile({ text: `` }, cssFilePath);
         await appendSelectedTextToFile(
-          { text: getComponentText(fileName, targets, sourceComponentConfig) },
+          {
+            text: getComponentText(fileName, targets, {
+              styleExt: generatedComponentOptions.styleExt,
+            }),
+          },
           tsFilePath
         );
-        await appendSelectedTextToFile(
-          { text: getSpecText(fileName) },
-          specFilePath
-        );
+        if (!generatedComponentOptions.skipTests) {
+          await appendSelectedTextToFile(
+            { text: getSpecText(fileName) },
+            specFilePath
+          );
+        }
 
         const componentInstance = getComponentInstance(fileName, targets);
         await persistFileSystemChanges(replaceSelectionWith(componentInstance));

--- a/src/modules/extract-to-folder.ts
+++ b/src/modules/extract-to-folder.ts
@@ -15,7 +15,6 @@ import {
   persistFileSystemChanges,
   replaceTextInFile,
 } from "../file-system";
-import { pascalCase } from "change-case";
 import {
   appendSelectedTextToFile,
   replaceSelectionWith,
@@ -26,6 +25,8 @@ import {
   getComponentText,
   getSpecText,
 } from "./extract-to-folder-template";
+import { getDeclarationChangeDescriptor } from "./module-declaration";
+import { selectDeclaringModules, sortModulePathsByProximity } from "./module-selection";
 import { resolveGeneratedComponentOptions } from "../angular-config";
 
 export async function extractToFolder() {
@@ -104,23 +105,35 @@ export async function extractToFolder() {
           }
         );
 
+        const targetModulePaths = targetModuleDocuments.map((moduleDocument) => moduleDocument.fileName);
+        const selectedModulePath = await getSelectedModulePath(targetModulePaths);
+
+        if (targetModuleDocuments.length > 1 && !selectedModulePath) {
+          return;
+        }
+
+        const selectedModulePaths = selectDeclaringModules(targetModulePaths, selectedModulePath);
+        const selectedModuleDocuments = targetModuleDocuments.filter((moduleDocument) =>
+          selectedModulePaths.includes(moduleDocument.fileName)
+        );
+
         const changes = await Promise.all(
-          targetModuleDocuments.map((moduleDocument) => {
+          selectedModuleDocuments.map((moduleDocument) => {
             const allText = moduleDocument.getText();
-            const matches = allText.match(/declarations\s*:\s*\[/) || [];
-
-            const idx = matches.index || 0;
-            const startOffset = idx;
-            const endOffset = idx + matches[0].length;
-
-            const start = moduleDocument.positionAt(startOffset);
-            const end = moduleDocument.positionAt(endOffset);
-            const targetText = `${matches[0]}\n    ${pascalCase(
+            const changeDescriptor = getDeclarationChangeDescriptor(
+              allText,
               fileName
-            )}Component,`;
+            );
+
+            if (!changeDescriptor) {
+              return null;
+            }
+
+            const start = moduleDocument.positionAt(changeDescriptor.startOffset);
+            const end = moduleDocument.positionAt(changeDescriptor.endOffset);
 
             return replaceTextInFile(
-              targetText,
+              changeDescriptor.targetText,
               start,
               end,
               moduleDocument.fileName
@@ -128,9 +141,11 @@ export async function extractToFolder() {
           })
         );
 
-        await persistFileSystemChanges(...changes);
+        await persistFileSystemChanges(
+          ...changes.filter((change) => change !== null)
+        );
         await Promise.all(
-          targetModuleDocuments.map((moduleDocument) => {
+          selectedModuleDocuments.map((moduleDocument) => {
             return importMissingDependencies(moduleDocument.fileName);
           })
         );
@@ -209,3 +224,23 @@ function trimChar(origString, charToTrim) {
   var regEx = new RegExp("^[" + charToTrim + "]+|[" + charToTrim + "]+$", "g");
   return origString.replace(regEx, "");
 };
+
+
+async function getSelectedModulePath(modulePaths: string[]): Promise<string | undefined> {
+  if (modulePaths.length <= 1) {
+    return modulePaths[0];
+  }
+
+  const sortedModulePaths = sortModulePathsByProximity(modulePaths, activeFileName());
+
+  const selectedModule = await vscode.window.showQuickPick(
+    sortedModulePaths.map((modulePath) => ({
+      label: path.basename(modulePath),
+      description: path.dirname(modulePath),
+      modulePath,
+    })),
+    { placeHolder: 'Select the NgModule that should declare the extracted component' }
+  );
+
+  return selectedModule?.modulePath;
+}

--- a/src/modules/inline-component-command.ts
+++ b/src/modules/inline-component-command.ts
@@ -1,0 +1,188 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activeFileName, getSelectionOffsetRange } from '../editor';
+import { inlineChildComponentTemplate, InlineMode } from './inline-component';
+
+export async function inlineComponentIntoCurrentComponent() {
+  const editor = vscode.window.activeTextEditor;
+  const fileName = activeFileName();
+
+  if (!editor || !fileName || !fileName.endsWith('.html')) {
+    vscode.window.showErrorMessage('Inline Component requires an active Angular template (.html) file.');
+    return;
+  }
+
+  const templateText = editor.document.getText();
+  const { start, end } = getSelectionOffsetRange() as { start: number; end: number };
+  const selectedText = templateText.slice(start, end);
+  const selector = readFirstTagName(selectedText);
+
+  if (!selector || !selector.includes('-')) {
+    vscode.window.showErrorMessage('Please select a component usage tag (for example: <app-button>).');
+    return;
+  }
+
+  const inlineMode = await askInlineMode();
+  if (!inlineMode) {
+    return;
+  }
+
+  const childSource = await findComponentSourceBySelector(selector);
+  if (!childSource) {
+    vscode.window.showErrorMessage(`Could not find component class for selector '${selector}'.`);
+    return;
+  }
+
+  const childTemplate = loadComponentTemplate(childSource.tsPath, childSource.tsText);
+  if (!childTemplate) {
+    vscode.window.showErrorMessage('Could not resolve child component template to inline.');
+    return;
+  }
+
+  const inlineResult = inlineChildComponentTemplate({
+    parentTemplate: templateText,
+    childSelector: selector,
+    childTemplate,
+    selectionStart: start,
+    selectionEnd: end,
+    mode: inlineMode,
+  });
+
+  if (!inlineResult.replacedCount) {
+    vscode.window.showErrorMessage('No matching component usages were found at the current selection.');
+    return;
+  }
+
+  const wholeRange = new vscode.Range(
+    editor.document.positionAt(0),
+    editor.document.positionAt(templateText.length)
+  );
+
+  await editor.edit((builder) => {
+    builder.replace(wholeRange, inlineResult.template);
+  });
+
+  const parentTsPath = fileName.replace(/\.html$/, '.ts');
+  if (inlineMode === 'all') {
+    const hasRemainingUsages = new RegExp(`<${escapeRegExp(selector)}\\b`).test(inlineResult.template);
+    if (!hasRemainingUsages) {
+      await removeParentImport(parentTsPath, childSource.componentClassName);
+      await deleteComponentFilesIfUnused(selector, childSource.tsPath);
+    }
+  }
+
+  vscode.window.showInformationMessage(`Inlined ${inlineResult.replacedCount} ${selector} usage(s).`);
+}
+
+async function askInlineMode(): Promise<InlineMode | undefined> {
+  const selection = await vscode.window.showQuickPick(
+    [
+      { label: 'Inline selected usage', value: 'selected' as InlineMode },
+      { label: 'Inline all usages in current file', value: 'all' as InlineMode },
+    ],
+    { placeHolder: 'Inline only selected usage or all usages in this component?' }
+  );
+
+  return selection?.value;
+}
+
+function readFirstTagName(selection: string): string | null {
+  const match = selection.match(/<\s*([a-zA-Z][\w-]*)\b/);
+  return match ? match[1] : null;
+}
+
+async function findComponentSourceBySelector(selector: string): Promise<{ tsPath: string; tsText: string; componentClassName: string } | null> {
+  const candidateUris = await vscode.workspace.findFiles('**/*.component.ts', '**/node_modules/**');
+
+  for (const uri of candidateUris) {
+    const tsPath = uri.fsPath;
+    const tsText = fs.readFileSync(tsPath, 'utf-8');
+    const selectorMatch = tsText.match(/selector\s*:\s*['"`]([^'"`]+)['"`]/);
+    if (!selectorMatch || selectorMatch[1] !== selector) {
+      continue;
+    }
+
+    const classMatch = tsText.match(/export\s+class\s+([\w_]+)/);
+    return {
+      tsPath,
+      tsText,
+      componentClassName: classMatch ? classMatch[1] : '',
+    };
+  }
+
+  return null;
+}
+
+function loadComponentTemplate(tsPath: string, tsText: string): string | null {
+  const inlineTemplateMatch = tsText.match(/template\s*:\s*`([\s\S]*?)`\s*,/);
+  if (inlineTemplateMatch) {
+    return inlineTemplateMatch[1];
+  }
+
+  const templateUrlMatch = tsText.match(/templateUrl\s*:\s*['"]([^'"]+)['"]/);
+  if (!templateUrlMatch) {
+    return null;
+  }
+
+  const templatePath = path.resolve(path.dirname(tsPath), templateUrlMatch[1]);
+  if (!fs.existsSync(templatePath)) {
+    return null;
+  }
+
+  return fs.readFileSync(templatePath, 'utf-8');
+}
+
+async function removeParentImport(parentTsPath: string, componentClassName: string): Promise<void> {
+  if (!componentClassName || !fs.existsSync(parentTsPath)) {
+    return;
+  }
+
+  const source = fs.readFileSync(parentTsPath, 'utf-8');
+  const next = source
+    .replace(new RegExp(`^.*\\b${escapeRegExp(componentClassName)}\\b.*\\n?`, 'gm'), (line) => {
+      if (line.includes('import') || line.includes('imports:') || line.includes('declarations:')) {
+        return '';
+      }
+      return line;
+    })
+    .replace(/imports\s*:\s*\[\s*,/g, 'imports: [')
+    .replace(/declarations\s*:\s*\[\s*,/g, 'declarations: [');
+
+  if (next !== source) {
+    fs.writeFileSync(parentTsPath, next, 'utf-8');
+  }
+}
+
+async function deleteComponentFilesIfUnused(selector: string, componentTsPath: string): Promise<void> {
+  const htmlUris = await vscode.workspace.findFiles('**/*.html', '**/node_modules/**');
+  const usageRegex = new RegExp(`<${escapeRegExp(selector)}\\b`);
+
+  for (const uri of htmlUris) {
+    const htmlText = fs.readFileSync(uri.fsPath, 'utf-8');
+    if (usageRegex.test(htmlText)) {
+      return;
+    }
+  }
+
+  const basePath = componentTsPath.replace(/\.component\.ts$/, '.component');
+  const candidateFiles = [
+    `${basePath}.ts`,
+    `${basePath}.html`,
+    `${basePath}.css`,
+    `${basePath}.scss`,
+    `${basePath}.sass`,
+    `${basePath}.less`,
+    `${basePath}.spec.ts`,
+  ];
+
+  candidateFiles.forEach((filePath) => {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/modules/inline-component.ts
+++ b/src/modules/inline-component.ts
@@ -1,0 +1,132 @@
+export type InlineMode = 'selected' | 'all';
+
+export interface InlineTemplateParams {
+  parentTemplate: string;
+  childSelector: string;
+  childTemplate: string;
+  selectionStart: number;
+  selectionEnd: number;
+  mode: InlineMode;
+}
+
+export interface InlineTemplateResult {
+  template: string;
+  replacedCount: number;
+}
+
+interface TagMatch {
+  start: number;
+  end: number;
+  attrs: string;
+  content: string;
+}
+
+export function inlineChildComponentTemplate(params: InlineTemplateParams): InlineTemplateResult {
+  const matches = findTagMatches(params.parentTemplate, params.childSelector);
+  if (!matches.length) {
+    return { template: params.parentTemplate, replacedCount: 0 };
+  }
+
+  const selectedMatches = params.mode === 'all'
+    ? matches
+    : matches.filter((match) => rangesOverlap(match.start, match.end, params.selectionStart, params.selectionEnd));
+
+  if (!selectedMatches.length) {
+    return { template: params.parentTemplate, replacedCount: 0 };
+  }
+
+  let nextTemplate = params.parentTemplate;
+  [...selectedMatches]
+    .sort((a, b) => b.start - a.start)
+    .forEach((match) => {
+      const inlined = renderInlinedTemplate(params.childTemplate, match.attrs, match.content);
+      nextTemplate = `${nextTemplate.slice(0, match.start)}${inlined}${nextTemplate.slice(match.end)}`;
+    });
+
+  return {
+    template: nextTemplate,
+    replacedCount: selectedMatches.length,
+  };
+}
+
+function renderInlinedTemplate(childTemplate: string, attrs: string, projectedContent: string): string {
+  const attrBindings = parseAttributeBindings(attrs);
+  let rendered = childTemplate;
+
+  Object.keys(attrBindings).forEach((key) => {
+    const value = attrBindings[key];
+    rendered = rendered.replace(new RegExp(`{{\\s*${escapeRegExp(key)}\\s*}}`, 'g'), `{{${value}}}`);
+  });
+
+  return rendered.replace(/<ng-content\b[^>]*><\/ng-content>|<ng-content\b[^>]*\/>/g, projectedContent);
+}
+
+function parseAttributeBindings(attrs: string): Record<string, string> {
+  const bindings: Record<string, string> = {};
+  const attrRegex = /(\[\([\w-]+\)\]|\[[\w-]+\]|bind-[\w-]+|[\w-]+)\s*=\s*("([^"]*)"|'([^']*)')/g;
+  let match: RegExpExecArray | null = attrRegex.exec(attrs);
+  while (match) {
+    const rawName = match[1];
+    const rawValue = match[3] !== undefined ? match[3] : match[4] || '';
+    const cleanName = normalizeBindingName(rawName);
+    if (cleanName) {
+      bindings[cleanName] = rawValue;
+    }
+    match = attrRegex.exec(attrs);
+  }
+
+  return bindings;
+}
+
+function normalizeBindingName(rawName: string): string {
+  if (rawName.startsWith('[(') && rawName.endsWith(')]')) {
+    return rawName.slice(2, -2);
+  }
+  if (rawName.startsWith('[') && rawName.endsWith(']')) {
+    return rawName.slice(1, -1);
+  }
+  if (rawName.startsWith('bind-')) {
+    return rawName.slice(5);
+  }
+  return rawName;
+}
+
+function findTagMatches(template: string, selector: string): TagMatch[] {
+  const escapedSelector = escapeRegExp(selector);
+  const pairRegex = new RegExp(`<${escapedSelector}(\\s[^>]*)?>([\\s\\S]*?)<\\/${escapedSelector}>`, 'g');
+  const selfClosingRegex = new RegExp(`<${escapedSelector}(\\s[^>]*)?\\s*\\/>`, 'g');
+
+  const matches: TagMatch[] = [];
+
+  let pairedMatch = pairRegex.exec(template);
+  while (pairedMatch) {
+    matches.push({
+      start: pairedMatch.index,
+      end: pairedMatch.index + pairedMatch[0].length,
+      attrs: pairedMatch[1] || '',
+      content: pairedMatch[2] || '',
+    });
+    pairedMatch = pairRegex.exec(template);
+  }
+
+  let selfMatch = selfClosingRegex.exec(template);
+  while (selfMatch) {
+    matches.push({
+      start: selfMatch.index,
+      end: selfMatch.index + selfMatch[0].length,
+      attrs: selfMatch[1] || '',
+      content: '',
+    });
+    selfMatch = selfClosingRegex.exec(template);
+  }
+
+  return matches.sort((a, b) => a.start - b.start);
+}
+
+function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/modules/module-declaration.ts
+++ b/src/modules/module-declaration.ts
@@ -1,0 +1,42 @@
+import {pascalCase} from 'change-case';
+
+export function getDeclarationChangeDescriptor(allText: string, fileName: string) {
+  const declarationsMatch = allText.match(/declarations\s*:\s*\[/);
+  if (!declarationsMatch || declarationsMatch.index === undefined) {
+    return null;
+  }
+
+  const declarationsText = declarationsMatch[0];
+  const declarationStartIdx = declarationsMatch.index;
+  const declarationEndIdx = declarationStartIdx + declarationsText.length;
+  const componentName = `${pascalCase(fileName)}Component`;
+  const targetModuleNameMatch = allText.match(/export\s+class\s+(\w+)/);
+  const targetModuleName = targetModuleNameMatch ? targetModuleNameMatch[1] : '';
+
+  const output = {
+    startOffset: declarationStartIdx,
+    endOffset: declarationEndIdx,
+    targetText: `${declarationsText}\n    ${componentName},`,
+  };
+
+  if (targetModuleName === 'AppModule') {
+    return output;
+  }
+
+  const exportsMatch = allText.match(/exports\s*:\s*\[/);
+  if (!exportsMatch || exportsMatch.index === undefined) {
+    return output;
+  }
+
+  if (exportsMatch.index < declarationEndIdx) {
+    return output;
+  }
+
+  const declarationsToExportsSpan = allText.slice(declarationEndIdx, exportsMatch.index);
+
+  return {
+    startOffset: declarationStartIdx,
+    endOffset: exportsMatch.index + exportsMatch[0].length,
+    targetText: `${declarationsText}\n    ${componentName},${declarationsToExportsSpan}${exportsMatch[0]}\n    ${componentName},`,
+  };
+}

--- a/src/modules/module-selection.ts
+++ b/src/modules/module-selection.ts
@@ -1,0 +1,35 @@
+import * as path from 'path';
+
+export function selectDeclaringModules(modulePaths: string[], selectedModulePath?: string): string[] {
+  if (!selectedModulePath) {
+    return modulePaths;
+  }
+
+  return modulePaths.filter((modulePath) => modulePath === selectedModulePath);
+}
+
+export function sortModulePathsByProximity(modulePaths: string[], sourceFilePath?: string): string[] {
+  return [...modulePaths].sort((modulePathA, modulePathB) => {
+    const sourceDirectory = path.dirname(sourceFilePath || "");
+    const scoreB = getCommonPathDepth(sourceDirectory, path.dirname(modulePathB));
+    const scoreA = getCommonPathDepth(sourceDirectory, path.dirname(modulePathA));
+
+    if (scoreB !== scoreA) {
+      return scoreB - scoreA;
+    }
+
+    return modulePathA.localeCompare(modulePathB);
+  });
+}
+
+function getCommonPathDepth(pathA: string, pathB: string): number {
+  const partsA = path.resolve(pathA).split(path.sep).filter(Boolean);
+  const partsB = path.resolve(pathB).split(path.sep).filter(Boolean);
+
+  let depth = 0;
+  while (depth < partsA.length && depth < partsB.length && partsA[depth] === partsB[depth]) {
+    depth += 1;
+  }
+
+  return depth;
+}

--- a/src/test/suite/angular-config.test.ts
+++ b/src/test/suite/angular-config.test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {resolveGeneratedComponentOptions} from '../../angular-config';
+
+suite('angular-config', () => {
+  test('uses component defaults from angular.json schematics', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arrr-angular-json-'));
+    fs.writeFileSync(
+      path.join(tempRoot, 'angular.json'),
+      JSON.stringify(
+        {
+          projects: {
+            app: {
+              schematics: {
+                '@schematics/angular:component': {
+                  style: 'scss',
+                  skipTests: true,
+                },
+              },
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const options = resolveGeneratedComponentOptions(tempRoot, 'css');
+
+    assert.strictEqual(options.styleExt, 'scss');
+    assert.strictEqual(options.skipTests, true);
+  });
+
+  test('falls back to source style and tests enabled when no angular.json exists', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arrr-no-angular-json-'));
+
+    const options = resolveGeneratedComponentOptions(tempRoot, 'less');
+
+    assert.strictEqual(options.styleExt, 'less');
+    assert.strictEqual(options.skipTests, false);
+  });
+});

--- a/src/test/suite/complete-action-provider.test.ts
+++ b/src/test/suite/complete-action-provider.test.ts
@@ -31,6 +31,15 @@ suite('CompleteActionProvider', function () {
     });
   });
 
+
+  test('returns inline action when a component usage tag is selected', async () => {
+    await withSelectedText('<app-button [label]="cta"></app-button>', async () => {
+      const result = provider.provideCodeActions() as vscode.Command[];
+
+      assert.ok(Array.isArray(result));
+      assert.ok(result.some((action) => action.command === 'extension.arrr.inline-component'));
+    });
+  });
   test('returns extract action for malformed-but-parseable snippets', async () => {
     await withSelectedText('<div>{{', async () => {
       const result = provider.provideCodeActions() as vscode.Command[];

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,9 +2,10 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 suite('Extension Activation', () => {
-  test('registers the extract command', async () => {
+  test('registers the refactor commands', async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes('extension.arrr.extract-to-folder'));
+    assert.ok(commands.includes('extension.arrr.inline-component'));
   });
 
   test('extension can be resolved and activated', async () => {

--- a/src/test/suite/extract-to-folder.test.ts
+++ b/src/test/suite/extract-to-folder.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert';
+
+import {getDeclarationChangeDescriptor} from '../../modules/module-declaration';
+
+suite('extract-to-folder', () => {
+  test('returns null when host module has no declarations array', () => {
+    const moduleText = `
+      import { NgModule } from '@angular/core';
+
+      @NgModule({
+        imports: [],
+      })
+      export class AppModule {}
+    `;
+
+    const change = getDeclarationChangeDescriptor(moduleText, 'child-card');
+
+    assert.strictEqual(change, null);
+  });
+
+  test('returns insertion descriptor when declarations array exists', () => {
+    const moduleText = `
+      @NgModule({
+        declarations: [AppComponent],
+      })
+      export class AppModule {}
+    `;
+
+    const change = getDeclarationChangeDescriptor(moduleText, 'child-card');
+
+    assert.ok(change);
+    assert.strictEqual(change?.targetText, 'declarations: [\n    ChildCardComponent,');
+  });
+
+  test('adds declaration and export when declaring module is not AppModule', () => {
+    const moduleText = `
+      @NgModule({
+        declarations: [ProfileCardComponent],
+        exports: [ProfileCardComponent],
+      })
+      export class ProfileModule {}
+    `;
+
+    const change = getDeclarationChangeDescriptor(moduleText, 'child-card');
+
+    assert.ok(change);
+    assert.ok(
+      change?.targetText.includes('declarations: [\n    ChildCardComponent,ProfileCardComponent],')
+    );
+    assert.ok(
+      change?.targetText.includes('exports: [\n    ChildCardComponent,')
+    );
+  });
+});

--- a/src/test/suite/inline-component.test.ts
+++ b/src/test/suite/inline-component.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert';
+import { inlineChildComponentTemplate } from '../../modules/inline-component';
+
+suite('inline-component', () => {
+  test('inlines only selected component usage when mode is selected', () => {
+    const parentTemplate = '<div><app-button [label]="save"></app-button><app-button [label]="cancel"></app-button></div>';
+    const firstStart = parentTemplate.indexOf('<app-button');
+    const firstEnd = parentTemplate.indexOf('</app-button>') + '</app-button>'.length;
+
+    const result = inlineChildComponentTemplate({
+      parentTemplate,
+      childSelector: 'app-button',
+      childTemplate: '<button>{{label}}</button>',
+      selectionStart: firstStart,
+      selectionEnd: firstEnd,
+      mode: 'selected',
+    });
+
+    assert.strictEqual(result.replacedCount, 1);
+    assert.strictEqual(result.template, '<div><button>{{save}}</button><app-button [label]="cancel"></app-button></div>');
+  });
+
+  test('inlines all component usages when mode is all', () => {
+    const parentTemplate = '<section><app-button [label]="save"></app-button><p>middle</p><app-button [label]="cancel"></app-button></section>';
+
+    const result = inlineChildComponentTemplate({
+      parentTemplate,
+      childSelector: 'app-button',
+      childTemplate: '<button>{{label}}</button>',
+      selectionStart: 0,
+      selectionEnd: 0,
+      mode: 'all',
+    });
+
+    assert.strictEqual(result.replacedCount, 2);
+    assert.strictEqual(result.template, '<section><button>{{save}}</button><p>middle</p><button>{{cancel}}</button></section>');
+  });
+
+  test('projects original content into ng-content when inlining', () => {
+    const parentTemplate = '<app-button><span>Press</span></app-button>';
+
+    const result = inlineChildComponentTemplate({
+      parentTemplate,
+      childSelector: 'app-button',
+      childTemplate: '<button><ng-content></ng-content></button>',
+      selectionStart: 0,
+      selectionEnd: parentTemplate.length,
+      mode: 'selected',
+    });
+
+    assert.strictEqual(result.replacedCount, 1);
+    assert.strictEqual(result.template, '<button><span>Press</span></button>');
+  });
+});

--- a/src/test/suite/module-selection.test.ts
+++ b/src/test/suite/module-selection.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+
+import {
+  selectDeclaringModules,
+  sortModulePathsByProximity,
+} from '../../modules/module-selection';
+
+suite('module selection', () => {
+  test('uses only selected module when a module is chosen from picker', () => {
+    const modulePaths = [
+      '/workspace/project/src/app/app.module.ts',
+      '/workspace/project/src/app/shared/shared.module.ts',
+    ];
+
+    const selected = selectDeclaringModules(modulePaths, '/workspace/project/src/app/shared/shared.module.ts');
+
+    assert.deepStrictEqual(selected, ['/workspace/project/src/app/shared/shared.module.ts']);
+  });
+
+  test('keeps current behavior when no module is selected', () => {
+    const modulePaths = [
+      '/workspace/project/src/app/app.module.ts',
+      '/workspace/project/src/app/shared/shared.module.ts',
+    ];
+
+    const selected = selectDeclaringModules(modulePaths);
+
+    assert.deepStrictEqual(selected, modulePaths);
+  });
+
+  test('sorts modules by proximity to the source component path', () => {
+    const sourcePath = '/workspace/project/src/app/profile/profile.component.html';
+    const modulePaths = [
+      '/workspace/project/src/app/app.module.ts',
+      '/workspace/project/src/app/profile/profile.module.ts',
+      '/workspace/project/src/app/shared/shared.module.ts',
+    ];
+
+    const sorted = sortModulePathsByProximity(modulePaths, sourcePath);
+
+    assert.deepStrictEqual(sorted, [
+      '/workspace/project/src/app/profile/profile.module.ts',
+      '/workspace/project/src/app/app.module.ts',
+      '/workspace/project/src/app/shared/shared.module.ts',
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure generated component files follow project Angular schematic defaults (for example `style` and `skipTests`) declared in `angular.json` so extracted components match workspace conventions.

### Description
- Add `src/angular-config.ts` with `resolveGeneratedComponentOptions` to read workspace- and project-level schematic options for `@schematics/angular:component` and normalize `style`/`skipTests` with safe fallbacks.
- Update `src/modules/extract-to-folder.ts` to use the resolved options so the generated CSS/stylesheet extension follows schematic `style` and `.component.spec.ts` files are omitted when `skipTests` is enabled.
- Add unit tests in `src/test/suite/angular-config.test.ts` that cover schematic override and fallback behavior.
- Preserve existing behavior when `angular.json` is absent or malformed by falling back to the source component style and enabling tests.

### Testing
- Wrote the tests first and observed an intentional failure confirming the behavior mismatch before the fix using `npx mocha --ui tdd out/test/suite/angular-config.test.js` (initial run failed showing `'css' !== 'scss'`).
- Recompiled and re-ran the angular-config tests with `npm run compile && npx mocha --ui tdd out/test/suite/angular-config.test.js`, and both tests passed.
- Attempted to run broader unit tests with `npx mocha --ui tdd out/test/suite/extract-to-folder-template.test.js out/test/suite/mini-project-fixture.test.js`, which fails in this environment due to the `vscode` module not being available outside the VS Code extension test host (this is an environment limitation, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40b3a08188324b54a3ac50a38c2ff)