### PR TITLE
Add inline component refactor with selected/all usage modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 	],
 	"activationEvents": [
 		"onLanguage:html",
-		"onCommand:extension.arrr.extract-to-folder"
+		"onCommand:extension.arrr.extract-to-folder",
+		"onCommand:extension.arrr.inline-component"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -27,6 +28,10 @@
 			{
 				"command": "extension.arrr.extract-to-folder",
 				"title": "Extract Angular component to folder"
+			},
+			{
+				"command": "extension.arrr.inline-component",
+				"title": "Inline Angular component into current component"
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 
 import {extractToFolder} from './modules/extract-to-folder';
+import {inlineComponentIntoCurrentComponent} from './modules/inline-component-command';
 import {templateParser} from './template-parser';
 import {getSelectedText} from './editor';
 
@@ -15,12 +16,21 @@ export class CompleteActionProvider implements vscode.CodeActionProvider {
       try {
         const output = templateParser.parse(text);
         if (!output.errors) {
-          return [
+          const actions: vscode.Command[] = [
             {
               command: 'extension.arrr.extract-to-folder',
               title: 'Extract Angular Component',
             },
           ];
+
+          if (/^\s*<\s*[a-zA-Z][\w-]*-[\w-]+\b/.test(text)) {
+            actions.push({
+              command: 'extension.arrr.inline-component',
+              title: 'Inline Angular Component',
+            });
+          }
+
+          return actions;
         }
       } catch (err) {
       }
@@ -37,6 +47,13 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'extension.arrr.extract-to-folder',
       extractToFolder
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'extension.arrr.inline-component',
+      inlineComponentIntoCurrentComponent
     )
   );
 

--- a/src/modules/inline-component-command.ts
+++ b/src/modules/inline-component-command.ts
@@ -1,0 +1,188 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { activeFileName, getSelectionOffsetRange } from '../editor';
+import { inlineChildComponentTemplate, InlineMode } from './inline-component';
+
+export async function inlineComponentIntoCurrentComponent() {
+  const editor = vscode.window.activeTextEditor;
+  const fileName = activeFileName();
+
+  if (!editor || !fileName || !fileName.endsWith('.html')) {
+    vscode.window.showErrorMessage('Inline Component requires an active Angular template (.html) file.');
+    return;
+  }
+
+  const templateText = editor.document.getText();
+  const { start, end } = getSelectionOffsetRange() as { start: number; end: number };
+  const selectedText = templateText.slice(start, end);
+  const selector = readFirstTagName(selectedText);
+
+  if (!selector || !selector.includes('-')) {
+    vscode.window.showErrorMessage('Please select a component usage tag (for example: <app-button>).');
+    return;
+  }
+
+  const inlineMode = await askInlineMode();
+  if (!inlineMode) {
+    return;
+  }
+
+  const childSource = await findComponentSourceBySelector(selector);
+  if (!childSource) {
+    vscode.window.showErrorMessage(`Could not find component class for selector '${selector}'.`);
+    return;
+  }
+
+  const childTemplate = loadComponentTemplate(childSource.tsPath, childSource.tsText);
+  if (!childTemplate) {
+    vscode.window.showErrorMessage('Could not resolve child component template to inline.');
+    return;
+  }
+
+  const inlineResult = inlineChildComponentTemplate({
+    parentTemplate: templateText,
+    childSelector: selector,
+    childTemplate,
+    selectionStart: start,
+    selectionEnd: end,
+    mode: inlineMode,
+  });
+
+  if (!inlineResult.replacedCount) {
+    vscode.window.showErrorMessage('No matching component usages were found at the current selection.');
+    return;
+  }
+
+  const wholeRange = new vscode.Range(
+    editor.document.positionAt(0),
+    editor.document.positionAt(templateText.length)
+  );
+
+  await editor.edit((builder) => {
+    builder.replace(wholeRange, inlineResult.template);
+  });
+
+  const parentTsPath = fileName.replace(/\.html$/, '.ts');
+  if (inlineMode === 'all') {
+    const hasRemainingUsages = new RegExp(`<${escapeRegExp(selector)}\\b`).test(inlineResult.template);
+    if (!hasRemainingUsages) {
+      await removeParentImport(parentTsPath, childSource.componentClassName);
+      await deleteComponentFilesIfUnused(selector, childSource.tsPath);
+    }
+  }
+
+  vscode.window.showInformationMessage(`Inlined ${inlineResult.replacedCount} ${selector} usage(s).`);
+}
+
+async function askInlineMode(): Promise<InlineMode | undefined> {
+  const selection = await vscode.window.showQuickPick(
+    [
+      { label: 'Inline selected usage', value: 'selected' as InlineMode },
+      { label: 'Inline all usages in current file', value: 'all' as InlineMode },
+    ],
+    { placeHolder: 'Inline only selected usage or all usages in this component?' }
+  );
+
+  return selection?.value;
+}
+
+function readFirstTagName(selection: string): string | null {
+  const match = selection.match(/<\s*([a-zA-Z][\w-]*)\b/);
+  return match ? match[1] : null;
+}
+
+async function findComponentSourceBySelector(selector: string): Promise<{ tsPath: string; tsText: string; componentClassName: string } | null> {
+  const candidateUris = await vscode.workspace.findFiles('**/*.component.ts', '**/node_modules/**');
+
+  for (const uri of candidateUris) {
+    const tsPath = uri.fsPath;
+    const tsText = fs.readFileSync(tsPath, 'utf-8');
+    const selectorMatch = tsText.match(/selector\s*:\s*['"`]([^'"`]+)['"`]/);
+    if (!selectorMatch || selectorMatch[1] !== selector) {
+      continue;
+    }
+
+    const classMatch = tsText.match(/export\s+class\s+([\w_]+)/);
+    return {
+      tsPath,
+      tsText,
+      componentClassName: classMatch ? classMatch[1] : '',
+    };
+  }
+
+  return null;
+}
+
+function loadComponentTemplate(tsPath: string, tsText: string): string | null {
+  const inlineTemplateMatch = tsText.match(/template\s*:\s*`([\s\S]*?)`\s*,/);
+  if (inlineTemplateMatch) {
+    return inlineTemplateMatch[1];
+  }
+
+  const templateUrlMatch = tsText.match(/templateUrl\s*:\s*['"]([^'"]+)['"]/);
+  if (!templateUrlMatch) {
+    return null;
+  }
+
+  const templatePath = path.resolve(path.dirname(tsPath), templateUrlMatch[1]);
+  if (!fs.existsSync(templatePath)) {
+    return null;
+  }
+
+  return fs.readFileSync(templatePath, 'utf-8');
+}
+
+async function removeParentImport(parentTsPath: string, componentClassName: string): Promise<void> {
+  if (!componentClassName || !fs.existsSync(parentTsPath)) {
+    return;
+  }
+
+  const source = fs.readFileSync(parentTsPath, 'utf-8');
+  const next = source
+    .replace(new RegExp(`^.*\\b${escapeRegExp(componentClassName)}\\b.*\\n?`, 'gm'), (line) => {
+      if (line.includes('import') || line.includes('imports:') || line.includes('declarations:')) {
+        return '';
+      }
+      return line;
+    })
+    .replace(/imports\s*:\s*\[\s*,/g, 'imports: [')
+    .replace(/declarations\s*:\s*\[\s*,/g, 'declarations: [');
+
+  if (next !== source) {
+    fs.writeFileSync(parentTsPath, next, 'utf-8');
+  }
+}
+
+async function deleteComponentFilesIfUnused(selector: string, componentTsPath: string): Promise<void> {
+  const htmlUris = await vscode.workspace.findFiles('**/*.html', '**/node_modules/**');
+  const usageRegex = new RegExp(`<${escapeRegExp(selector)}\\b`);
+
+  for (const uri of htmlUris) {
+    const htmlText = fs.readFileSync(uri.fsPath, 'utf-8');
+    if (usageRegex.test(htmlText)) {
+      return;
+    }
+  }
+
+  const basePath = componentTsPath.replace(/\.component\.ts$/, '.component');
+  const candidateFiles = [
+    `${basePath}.ts`,
+    `${basePath}.html`,
+    `${basePath}.css`,
+    `${basePath}.scss`,
+    `${basePath}.sass`,
+    `${basePath}.less`,
+    `${basePath}.spec.ts`,
+  ];
+
+  candidateFiles.forEach((filePath) => {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/modules/inline-component.ts
+++ b/src/modules/inline-component.ts
@@ -1,0 +1,132 @@
+export type InlineMode = 'selected' | 'all';
+
+export interface InlineTemplateParams {
+  parentTemplate: string;
+  childSelector: string;
+  childTemplate: string;
+  selectionStart: number;
+  selectionEnd: number;
+  mode: InlineMode;
+}
+
+export interface InlineTemplateResult {
+  template: string;
+  replacedCount: number;
+}
+
+interface TagMatch {
+  start: number;
+  end: number;
+  attrs: string;
+  content: string;
+}
+
+export function inlineChildComponentTemplate(params: InlineTemplateParams): InlineTemplateResult {
+  const matches = findTagMatches(params.parentTemplate, params.childSelector);
+  if (!matches.length) {
+    return { template: params.parentTemplate, replacedCount: 0 };
+  }
+
+  const selectedMatches = params.mode === 'all'
+    ? matches
+    : matches.filter((match) => rangesOverlap(match.start, match.end, params.selectionStart, params.selectionEnd));
+
+  if (!selectedMatches.length) {
+    return { template: params.parentTemplate, replacedCount: 0 };
+  }
+
+  let nextTemplate = params.parentTemplate;
+  [...selectedMatches]
+    .sort((a, b) => b.start - a.start)
+    .forEach((match) => {
+      const inlined = renderInlinedTemplate(params.childTemplate, match.attrs, match.content);
+      nextTemplate = `${nextTemplate.slice(0, match.start)}${inlined}${nextTemplate.slice(match.end)}`;
+    });
+
+  return {
+    template: nextTemplate,
+    replacedCount: selectedMatches.length,
+  };
+}
+
+function renderInlinedTemplate(childTemplate: string, attrs: string, projectedContent: string): string {
+  const attrBindings = parseAttributeBindings(attrs);
+  let rendered = childTemplate;
+
+  Object.keys(attrBindings).forEach((key) => {
+    const value = attrBindings[key];
+    rendered = rendered.replace(new RegExp(`{{\\s*${escapeRegExp(key)}\\s*}}`, 'g'), `{{${value}}}`);
+  });
+
+  return rendered.replace(/<ng-content\b[^>]*><\/ng-content>|<ng-content\b[^>]*\/>/g, projectedContent);
+}
+
+function parseAttributeBindings(attrs: string): Record<string, string> {
+  const bindings: Record<string, string> = {};
+  const attrRegex = /(\[\([\w-]+\)\]|\[[\w-]+\]|bind-[\w-]+|[\w-]+)\s*=\s*("([^"]*)"|'([^']*)')/g;
+  let match: RegExpExecArray | null = attrRegex.exec(attrs);
+  while (match) {
+    const rawName = match[1];
+    const rawValue = match[3] !== undefined ? match[3] : match[4] || '';
+    const cleanName = normalizeBindingName(rawName);
+    if (cleanName) {
+      bindings[cleanName] = rawValue;
+    }
+    match = attrRegex.exec(attrs);
+  }
+
+  return bindings;
+}
+
+function normalizeBindingName(rawName: string): string {
+  if (rawName.startsWith('[(') && rawName.endsWith(')]')) {
+    return rawName.slice(2, -2);
+  }
+  if (rawName.startsWith('[') && rawName.endsWith(']')) {
+    return rawName.slice(1, -1);
+  }
+  if (rawName.startsWith('bind-')) {
+    return rawName.slice(5);
+  }
+  return rawName;
+}
+
+function findTagMatches(template: string, selector: string): TagMatch[] {
+  const escapedSelector = escapeRegExp(selector);
+  const pairRegex = new RegExp(`<${escapedSelector}(\\s[^>]*)?>([\\s\\S]*?)<\\/${escapedSelector}>`, 'g');
+  const selfClosingRegex = new RegExp(`<${escapedSelector}(\\s[^>]*)?\\s*\\/>`, 'g');
+
+  const matches: TagMatch[] = [];
+
+  let pairedMatch = pairRegex.exec(template);
+  while (pairedMatch) {
+    matches.push({
+      start: pairedMatch.index,
+      end: pairedMatch.index + pairedMatch[0].length,
+      attrs: pairedMatch[1] || '',
+      content: pairedMatch[2] || '',
+    });
+    pairedMatch = pairRegex.exec(template);
+  }
+
+  let selfMatch = selfClosingRegex.exec(template);
+  while (selfMatch) {
+    matches.push({
+      start: selfMatch.index,
+      end: selfMatch.index + selfMatch[0].length,
+      attrs: selfMatch[1] || '',
+      content: '',
+    });
+    selfMatch = selfClosingRegex.exec(template);
+  }
+
+  return matches.sort((a, b) => a.start - b.start);
+}
+
+function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/test/suite/complete-action-provider.test.ts
+++ b/src/test/suite/complete-action-provider.test.ts
@@ -31,6 +31,15 @@ suite('CompleteActionProvider', function () {
     });
   });
 
+
+  test('returns inline action when a component usage tag is selected', async () => {
+    await withSelectedText('<app-button [label]="cta"></app-button>', async () => {
+      const result = provider.provideCodeActions() as vscode.Command[];
+
+      assert.ok(Array.isArray(result));
+      assert.ok(result.some((action) => action.command === 'extension.arrr.inline-component'));
+    });
+  });
   test('returns extract action for malformed-but-parseable snippets', async () => {
     await withSelectedText('<div>{{', async () => {
       const result = provider.provideCodeActions() as vscode.Command[];

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,9 +2,10 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 suite('Extension Activation', () => {
-  test('registers the extract command', async () => {
+  test('registers the refactor commands', async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes('extension.arrr.extract-to-folder'));
+    assert.ok(commands.includes('extension.arrr.inline-component'));
   });
 
   test('extension can be resolved and activated', async () => {

--- a/src/test/suite/inline-component.test.ts
+++ b/src/test/suite/inline-component.test.ts
@@ -1,0 +1,54 @@
+import * as assert from 'assert';
+import { inlineChildComponentTemplate } from '../../modules/inline-component';
+
+suite('inline-component', () => {
+  test('inlines only selected component usage when mode is selected', () => {
+    const parentTemplate = '<div><app-button [label]="save"></app-button><app-button [label]="cancel"></app-button></div>';
+    const firstStart = parentTemplate.indexOf('<app-button');
+    const firstEnd = parentTemplate.indexOf('</app-button>') + '</app-button>'.length;
+
+    const result = inlineChildComponentTemplate({
+      parentTemplate,
+      childSelector: 'app-button',
+      childTemplate: '<button>{{label}}</button>',
+      selectionStart: firstStart,
+      selectionEnd: firstEnd,
+      mode: 'selected',
+    });
+
+    assert.strictEqual(result.replacedCount, 1);
+    assert.strictEqual(result.template, '<div><button>{{save}}</button><app-button [label]="cancel"></app-button></div>');
+  });
+
+  test('inlines all component usages when mode is all', () => {
+    const parentTemplate = '<section><app-button [label]="save"></app-button><p>middle</p><app-button [label]="cancel"></app-button></section>';
+
+    const result = inlineChildComponentTemplate({
+      parentTemplate,
+      childSelector: 'app-button',
+      childTemplate: '<button>{{label}}</button>',
+      selectionStart: 0,
+      selectionEnd: 0,
+      mode: 'all',
+    });
+
+    assert.strictEqual(result.replacedCount, 2);
+    assert.strictEqual(result.template, '<section><button>{{save}}</button><p>middle</p><button>{{cancel}}</button></section>');
+  });
+
+  test('projects original content into ng-content when inlining', () => {
+    const parentTemplate = '<app-button><span>Press</span></app-button>';
+
+    const result = inlineChildComponentTemplate({
+      parentTemplate,
+      childSelector: 'app-button',
+      childTemplate: '<button><ng-content></ng-content></button>',
+      selectionStart: 0,
+      selectionEnd: parentTemplate.length,
+      mode: 'selected',
+    });
+
+    assert.strictEqual(result.replacedCount, 1);
+    assert.strictEqual(result.template, '<button><span>Press</span></button>');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide the reverse of `extract`: allow inlining a child component into the current parent template either for a single selected usage or for all usages in the file. 
- Handle real-world edge cases: multiple sibling usages, attribute binding syntaxes, `ng-content` projection, and safe cleanup of imports/files when inlining all usages.
- Follow a tests-first workflow so the implementation is driven by failing tests that are then fixed.

### Description
- Add a transformation engine `inlineChildComponentTemplate` in `src/modules/inline-component.ts` that finds component tag occurrences, supports `selected` vs `all` modes, rewrites bound inputs into template interpolations, and replaces `<ng-content>` with projected content.
- Add a command implementation `inlineComponentIntoCurrentComponent` in `src/modules/inline-component-command.ts` that prompts the user for mode, resolves the child component by selector (`template` or `templateUrl`), applies the inlining to the active template, and optionally performs cleanup (remove parent import/declaration lines and delete child component files when globally unused).
- Wire the new command into the extension by registering `extension.arrr.inline-component` and exposing an `Inline Angular Component` code action in `src/extension.ts` when a component-like tag is selected.
- Add tests and test-suite changes: new unit tests `src/test/suite/inline-component.test.ts` that cover selected/all modes and `ng-content` projection, update `complete-action-provider.test.ts` to expect the inline action, and update `extension.test.ts` to assert the command is registered, plus add the activation/contribution in `package.json`.

### Testing
- Ran `npm run compile` and `npm run lint`, both completed successfully. 
- Ran the new inline unit tests with Mocha (`npx mocha -u tdd out/test/suite/inline-component.test.js`), and they pass (`3 passing`).
- Observed and fixed initial failing assertions during TDD (initial test run failed, subsequent run passed after implementing the logic). 
- Attempted extension-host integration tests via `npm test -- --grep ...`, but those were blocked in this environment by the downloaded VS Code binary missing system library `libatk-1.0.so.0`, so activation/host tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4149bcf748324b1274e3c764ef922)